### PR TITLE
chore: delete extra files

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,0 @@
-{
-    "workspace.checkThirdParty": false
-}


### PR DESCRIPTION
`.luarc.json` is no longer needed with #1, and `assets/.gitkeep` is an artifact from the template repository only used to keep the `assets` folder when there are no files inside.